### PR TITLE
CLOUD-1735- removing support for ucp versions <2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ setup. Consult the UCP documentation for details of this options.
 class { 'docker_ddc':
   controller                => true,
   host_address              => ::ipaddress_eth1,
-  version                   => '1.0.0',
+  version                   => '2.2.7',
   usage                     => false,
   tracking                  => false,
   subject_alternative_names => ::ipaddress_eth1,
@@ -71,48 +71,18 @@ class { 'docker_ddc':
 }
 ```
 
-Note that `license_file` option will only work with versions of UCP
-later than 0.8.0.
-
 ### Joining a Node to UCP
-
-# Version =< 1
-You can use the same class on another node to join it to an existing
-UCP.
-
-```puppet
-class { 'docker_ddc':
-  ucp_url     => 'https://ucp-controller.example.com',
-  fingerprint => 'the-ucp-fingerprint-for-your-install',
-}
-```
 
 The default username and password are used, so it's likely that you'll
 need to provide those in parameters. The class also takes a number of
 other parameters useful for joininng. Again these should map to the
 options in the official UCP documetation.
 
-```puppet
-class { 'docker_ddc':
-  ucp_url                   => 'https://ucp-controller.example.com',
-  fingerprint               => 'the-ucp-fingerprint-for-your-install',
-  username                  => 'admin',
-  password                  => 'orca',
-  host_address              => ::ipaddress_eth1,
-  subject_alternative_names => ::ipaddress_eth1,
-  replica                   => true,
-  version                   => '0.8.0',
-  usage                     => false,
-  tracking                  => false,
-}
-```
-# Version 2 and above
-In UCP version 2 Docker has changed the underlying cluster scheduler from Swarm legacy to Swarm mode, because of that change the join flags have also changed.
-To join to a v2 manager (formally a controller in v1) please use the following:
+To join to a v2 manager please use the following:
 
 ```puppet
 class { 'docker_ddc':
-  version => '2.1.0',
+  version => '2.2.7',
   token => 'Your join token here',
   listen_address => '192.168.1.2',
   advertise_address => '192.168.1.2',
@@ -196,8 +166,8 @@ destroy => true
 
 ## Limitations
 
-This module only supports UCP version 1.9 and above.
-UCP only supports RHEL 7.0, 7.1, 7.2, Ubuntu 14.04, 16.04 and CentOS 7.1
+This module only supports UCP version 2.0 and above.
+UCP only supports RHEL 7.0, 7.1, 7.2, 7.4, Ubuntu 14.04, 16.04 and CentOS 7.1, 7.4
 
 
 ## Maintainers

--- a/lib/puppet/parser/functions/ucp_join_flags.rb
+++ b/lib/puppet/parser/functions/ucp_join_flags.rb
@@ -7,7 +7,6 @@ module Puppet::Parser::Functions
     flags << '--disable-usage' unless opts['usage']
     flags << '--replica' if opts['replica'] == true
     flags << "--image-version '#{opts['version']}'" if opts['version'] && opts['version'].to_s != 'undef'
-    flags << "--fingerprint '#{opts['fingerprint']}'" if opts['fingerprint'] && opts['fingerprint'].to_s != 'undef'
     flags << "--url '#{opts['ucp_url']}'" if opts['ucp_url'] && opts['ucp_url'].to_s != 'undef'
 
     multi_flags = lambda do |values, format|

--- a/manifests/ucp.pp
+++ b/manifests/ucp.pp
@@ -63,10 +63,6 @@
 # [*ucp_id*]
 #   The ID for the UCP. Used when deleting UCP with ensure => absent.
 #
-# [*fingerprint*]
-#   The certificate fingerprint for the UCP controller.
-#   Required for nodes.
-#
 # [*token*]
 #  This is the authtentication token used for UCP 2.0 and above
 #  Required only if you are using UCP version 2.0 or higher
@@ -114,7 +110,6 @@ class docker_ddc::ucp (
   Optional[String] $ucp_url                                         = $docker_ddc::ucp_url,
   Optional[String] $ucp_manager                                     = $docker_ddc::ucp_manager,
   Optional[String] $ucp_id                                          = $docker_ddc::ucp_id,
-  Optional[String] $fingerprint                                     = $docker_ddc::fingerprint,
   Optional[String] $token                                           = $docker_ddc::token,
   Optional[String] $listen_address                                  = $docker_ddc::listen_address,
   Optional[String] $advertise_address                               = $docker_ddc::advertise_address,
@@ -144,11 +139,6 @@ class docker_ddc::ucp (
     if !$controller {
       if !$ucp_url {
         fail translate(('When joining UCP you must provide a URL.'))
-      }
-      if versioncmp($version, '1.1.3') <= 0 {
-        if !$fingerprint {
-          fail translate(('When joining UCP v1 you must provide a fingerprint.'))
-        }
       }
     }
   }
@@ -211,7 +201,6 @@ class docker_ddc::ucp (
         host_address       => $host_address,
         tracking           => $tracking,
         usage              => $usage,
-        fingerprint        => $fingerprint,
         ucp_url            => $ucp_url,
         replica            => $replica,
         dns_servers        => any2array($dns_servers),
@@ -229,11 +218,8 @@ class docker_ddc::ucp (
       }
 
       else {
-        exec { 'Join Docker Universal Control Plane v1':
-          command => "docker run --rm -v ${docker_socket_path}:/var/run/docker.sock -e 'UCP_ADMIN_USER=${username}' -e 'UCP_ADMIN_PASSWORD=${password}' --name ucp docker/ucp join ${join_flags}", # lint:ignore:140chars
-          unless  => $join_unless,
+          translate('UCP versions below 2.0 are no longer supported')
         }
       }
     }
   }
-}

--- a/spec/classes/docker_ddc_spec.rb
+++ b/spec/classes/docker_ddc_spec.rb
@@ -196,7 +196,6 @@ describe 'docker_ddc' do
             'version',
             'ucp_url',
             'ucp_id',
-            'fingerprint',
             'username',
             'password',
           ].each do |param|
@@ -223,36 +222,6 @@ describe 'docker_ddc' do
             end
           end
         end
-
-        context 'joining UCP v1' do
-          context 'with the minimum properties v1' do
-      let(:fingerprint) { '12345' }
-            let(:ucp_url) { 'https://ucp' }
-      let(:params) do
-              {
-    'version' => '1',
-    'fingerprint' => fingerprint,
-                'ucp_url' => ucp_url,
-              }
-            end
-      it do
-        should contain_class('Docker_ddc').with_controller(false)
-              should contain_exec('Join Docker Universal Control Plane v1')
-    .with_logoutput(true)
-                .with_tries(3)
-                .with_try_sleep(5)
-                .with_command(/join/)
-                .with_command(/\-\-fingerprint '#{fingerprint}'/)
-                .with_command(/\-\-url '#{ucp_url}'/)
-                .with_unless('docker inspect ucp-proxy')
-              should_not contain_exec('Install Docker Universal Control Plane')
-                .with_command(/\-\-disable\-usage/)
-              should_not contain_exec('Install Docker Universal Control Plane')
-                .with_command(/\-\-disable\-tracking/)
-               end
-              end
-      end
-          end
 
      context 'joining UCP v2' do
        context 'with the minimum properties v2' do
@@ -299,17 +268,6 @@ describe 'docker_ddc' do
               contain_exec('Join Docker Universal Control Plane v2')
             end
           end
-
-   context 'without passing a UCP URL' do
-    let(:params) do
-              {
-                'fingerprint' => '12345',
-    'version'     => '2',
-              }
-            end
-            it do
-              contain_exec('Join Docker Universal Control Plane v2')
-            end
 
         context 'uninstalling UCP' do
           let(:ucp_id) { "1" }


### PR DESCRIPTION
This PR removes support for UCP versions <2.0. 